### PR TITLE
Aktualisiere die Versionsnummer in package.json auf 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-css-plugin",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Obsidian Plugin mit dynamischem CSS und Einstellungen",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the `my-css-plugin` package, reflecting a new release.

- Bumped the version in `package.json` from `0.1.0` to `1.0.1` to indicate a new release.